### PR TITLE
Add now required `teamId` option to notarization script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # IS_NIGHTLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}

--- a/build_resources/notarize.js
+++ b/build_resources/notarize.js
@@ -40,5 +40,6 @@ exports.default = async function notarizing(context) {
 				appPath: `${appOutDir}/${appName}.app`,
 				appleId: process.env.AC_USERNAME,
 				appleIdPassword: process.env.AC_PASSWORD,
+				teamId: process.env.AC_TEAM_ID,
 		});
 };


### PR DESCRIPTION
The options for the `notarize` call in the script are different depending on the setting of the `tool` option:

https://github.com/electron/notarize/tree/v1.2.1#method-notarizeopts-promisevoid

Now that the `tool` option has been changed from the default `legacy` to `notarytool`, there is an additional `teamId` option, which is the [Apple Developer Program team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/) associated with the macOS signing certificate. The previously missing option caused the build to fail:

https://github.com/per1234/lab-micropython-editor/actions/runs/5275384855/jobs/9540804966#step:4:107

```text
⨯ The teamId property is required when using notarization with password credentials  failedTask=build stackTrace=Error: The teamId property is required when using notarization with password credentials
```

Following [the convention established in the Arduino IDE build system](https://github.com/arduino/arduino-ide/commit/0a87fd00f38c923a36ce22d9a787fd071a6173e7), I used an [encrypted repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) to configure the team ID value. The use of a secret is not absolutely necessary because, unlike some of the other credentials used by the build system, the team ID is not actually a secret and can be seen in plaintext by anyone who examines the notarized application.

The Team ID is passed from the GitHub Actions workflow to the script using an environment variable, as is considered best practices and already done for the other notarization credentials.

I ran a test release in my fork using my personal certificate and Apple Developer Program account:

https://github.com/per1234/lab-micropython-editor/releases/tag/0.0.0-rc.2